### PR TITLE
Sort received segments by start time

### DIFF
--- a/resources/lib/player_listener.py
+++ b/resources/lib/player_listener.py
@@ -47,8 +47,6 @@ def get_sponsor_segments(
         logger.warning("received empty list of sponsor segments for video %s", video_id)
         return None
 
-    segments = sorted(segments, key=lambda SponsorSegment: SponsorSegment.start)
-
     logger.debug("got segments %s", segments)
     assert _sanity_check_segments(segments)
     return segments

--- a/resources/lib/player_listener.py
+++ b/resources/lib/player_listener.py
@@ -47,6 +47,8 @@ def get_sponsor_segments(
         logger.warning("received empty list of sponsor segments for video %s", video_id)
         return None
 
+    segments = sorted(segments, key=lambda SponsorSegment: SponsorSegment.start)
+
     logger.debug("got segments %s", segments)
     assert _sanity_check_segments(segments)
     return segments

--- a/resources/lib/sponsorblock/api.py
+++ b/resources/lib/sponsorblock/api.py
@@ -93,7 +93,7 @@ class SponsorBlockAPI:
             seg = SponsorSegment(raw["UUID"], raw["category"], start, end)
             segments.append(seg)
 
-        return segments
+        return sorted(segments, key=lambda SponsorSegment: SponsorSegment.start)
 
     def vote_sponsor_segment(
         self, segment, upvote=False


### PR DESCRIPTION
This sorts the received sponsor segments by start time to prevent the addon only skipping the first segment in the list which is quite often (or possibly always?) the outro.

Not sure why the assertion does not stop further steps.

This is a pretty simple fix, there might be better ways for this, but as I'm debugging and creating this PR through my phone I think it's good enough for now :)