### PR TITLE
Get current player's time after a delay instead of relying on seek target

### DIFF
--- a/resources/lib/player_listener.py
+++ b/resources/lib/player_listener.py
@@ -142,7 +142,7 @@ class PlayerListener(PlayerCheckpointListener):
         self.start_listener()
 
     def _select_next_checkpoint(self):
-        current_time = self._get_current_time()
+        current_time = self.getTime()
         logger.debug("searching for next segment after %g", current_time)
         self._next_segment = next(
             (seg for seg in self._segments if seg.start > current_time), None

--- a/resources/lib/utils/checkpoint_listener.py
+++ b/resources/lib/utils/checkpoint_listener.py
@@ -82,7 +82,7 @@ class PlayerCheckpointListener(xbmc.Player):
             self._select_next_checkpoint()
             return
 
-        overshoot = self._get_current_time() - cp
+        overshoot = self.getTime() - cp
         if overshoot > MAX_OVERSHOOT:
             logger.warning(
                 "overshot checkpoint %s by %s second(s), ignoring", cp, overshoot


### PR DESCRIPTION
Currently this plugin uses offset of the onPlayBackSeek to get the seek time.

Unfortunately, this method only reports the optimistic seek target. Actual post-seek position can be different, for example due to the video keyframes. This causes the reported time to actually be couple of seconds early, which causes overshot and prevents skip from occurring.

PR fixes this by replacing the offset checking mechanism with simply waiting half a second after skip (to ensure getTime() reports proper value) and then recalculating next checkpoint as usual.

This fixes #23