### PR TITLE
chore: support flatpak in quick-install

### DIFF
--- a/tools/create-release.sh
+++ b/tools/create-release.sh
@@ -24,7 +24,6 @@ function create_tempdir() {
   work_dir=$(mktemp --directory)
   if [[ ! "$work_dir" || ! -d "$work_dir" ]]; then
     exit_with_error "could not create temp dir"
-    exit 1
   fi
 
   echo "$work_dir"

--- a/tools/quick-install.sh
+++ b/tools/quick-install.sh
@@ -65,12 +65,13 @@ function reinstall_addon() {
 function start_kodi() {
   echo "starting kodi"
 
-  if [[ -z $FLATPAK ]]
+  if [[ $FLATPAK ]]
   then
-    kodi &>/dev/null &
-  else
     flatpak run tv.kodi.Kodi
+    return
   fi
+
+  kodi &>/dev/null &
 }
 
 function tail_log() {

--- a/tools/quick-install.sh
+++ b/tools/quick-install.sh
@@ -7,8 +7,14 @@ function exit_with_error() {
 }
 
 KODI_PATH="$HOME/.kodi"
+
 if [[ ! -d $KODI_PATH ]]; then
-  exit_with_error "kodi not found at $KODI_PATH"
+  KODI_PATH="$HOME/.var/app/tv.kodi.Kodi/data"
+  FLATPAK=1
+fi
+
+if [[ ! -d $KODI_PATH ]]; then
+  exit_with_error "kodi not found"
 fi
 
 if [[ ! -f addon.xml ]]; then
@@ -58,7 +64,13 @@ function reinstall_addon() {
 
 function start_kodi() {
   echo "starting kodi"
-  kodi &>/dev/null &
+
+  if [[ -z $FLATPAK ]]
+  then
+    kodi &>/dev/null &
+  else
+    flatpak run tv.kodi.Kodi
+  fi
 }
 
 function tail_log() {


### PR DESCRIPTION
I was working on a PR (will submit soon) but did some chores before hand.

This one adds Flatpak support to the `quick-install.sh` script you've made. Just makes it a bit easier to contribute if one has Kodi installed via Flatpak.