### PR TITLE
feat: add invidious support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 This is an **unofficial** port of the [SponsorBlock](https://sponsor.ajay.app/) browser extension.
 It works as an extension to the [YouTube Plugin](https://github.com/anxdpanic/plugin.video.youtube).
 
-Once installed, the add-on will automatically skip sponsor segments in all YouTube videos you watch.
+Once installed, the add-on will automatically skip sponsor segments in all YouTube and Invidious videos you watch.
 
-For a detailed explanation of how SponsorSkip works please visit the [offical website](https://sponsor.ajay.app/).
+For a detailed explanation of how SponsorBlock works please visit the [offical website](https://sponsor.ajay.app/).
 
 ## Installation
 

--- a/addon.xml
+++ b/addon.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="script.service.sponsorblock" version="0.4.0" name="SponsorBlock" provider-name="siku2">
+<addon id="script.service.sponsorblock" version="0.5.0" name="SponsorBlock" provider-name="siku2">
     <requires>
         <import addon="script.module.requests" version="2.15.1"/>
         <import addon="script.module.six" version="1.13.0"/>
-        <import addon="plugin.video.youtube" version="6.7.0"/>
+        <import addon="plugin.video.youtube" version="6.7.0" optional="true"/>
+        <import addon="plugin.video.invidious" version="2.1.1" optional="true"/>
     </requires>
 
     <extension point="xbmc.service" library="service.py"/>
@@ -12,7 +13,7 @@
         <menu id="kodi.core.main">
             <item library="context.py">
                 <label>32027</label>
-                <visible>String.IsEqual(ListItem.Property(Addon.ID),plugin.video.youtube)</visible>
+                <visible>String.IsEqual(ListItem.Property(Addon.ID),plugin.video.youtube) | String.IsEqual(ListItem.Property(Addon.ID),plugin.video.invidious)</visible>
             </item>
         </menu>
     </extension>
@@ -20,7 +21,7 @@
     <extension point="xbmc.addon.metadata">
         <summary lang="en_GB">Skip YouTube in-video sponsors</summary>
         <description lang="en_GB">
-SponsorBlock browser extension ported to Kodi's YouTube plugin.
+SponsorBlock browser extension ported to Kodi's YouTube and Invidious plugins.
 
 SponsorBlock is a crowdsourced project to skip sponsor segments in YouTube videos.
 Users submit when a sponsor happens and the add-on automatically skips sponsors it knows about.
@@ -31,6 +32,7 @@ Users submit when a sponsor happens and the add-on automatically skips sponsors 
 - Add option to reduce all skips by some time (#30)
 - Ignore segments that do not fit into reduce skips setting (#31)
 - Reset existing playback when new video starts playing (#32)
+- Support for Kodi's Invidious plugin
         </news>
 
         <summary lang="de">Überspringe Sponsoren, betteln um Abonnenten und mehr in YouTube Videos</summary>

--- a/resources/lib/monitor.py
+++ b/resources/lib/monitor.py
@@ -84,7 +84,7 @@ class Monitor(xbmc.Monitor):
         self._player_listener.preload_segments(video_id)
 
     def onNotification(self, sender, method, data):  # type: (str, str, str) -> None
-        if sender != youtube_api.ADDON_ID:
+        if sender not in youtube_api.ADDON_IDS:
             return
 
         try:

--- a/resources/lib/player_listener.py
+++ b/resources/lib/player_listener.py
@@ -38,7 +38,7 @@ def _sanity_check_segments(segments):  # type: (Iterable[SponsorSegment]) -> boo
 
 def get_sponsor_segments(
     api, video_id
-):  # type: (SponsorBlockAPI, str) -> Optional[List[SponsorSegment]]
+):  # type: (SponsorBlockAPI, str) -> Optional[list[SponsorSegment]]
     try:
         segments = api.get_skip_segments(video_id)
     except NotFound:
@@ -80,7 +80,7 @@ class PlayerListener(PlayerCheckpointListener):
         self._load_segment_lock = threading.Lock()
         self._ignore_next_video_id = None
         self._segments_video_id = None
-        self._segments = []  # List[SponsorSegment]
+        self._segments = []  # list[SponsorSegment]
         self._next_segment = None  # type: Optional[SponsorSegment]
 
         # set by `onPlaybackStarted` and then read (/ reset) by `onAVStarted`


### PR DESCRIPTION
Adds support for Invidious, aimed at the [lekma/video.plugin.invidious](https://github.com/lekma/plugin.video.invidious) version.
The version of Invidious currently in the Kodi repos is unmaintained and the public GitHub repo was archived.

* Updates the README and addon description to mention Invidious.
* Makes YouTube an optional addon, and adds Invidious as an optional addon.

On the side I did a few minor refactors.

#### Documentation

Documentation for variables can be done by doing the docstring syntax under it.

![image](https://github.com/siku2/script.service.sponsorblock/assets/22801583/fe6d06f7-639b-4454-b09f-3cda6577275b)
> Now that the comment was moved to a docstring, we get hints when hovering over variables.

#### Types

Normally types are lowercase, i.e. `list[str]`, not `List[str]` afaik.

### Notes

* [`#get_video_id`](https://github.com/siku2/script.service.sponsorblock/pull/45/files#diff-fb4f0e5d3711634b047f71c3a8b8dfedab5d8fc1fc766320858939e65964d98aL136) is no longer YouTube specific. Should we consider moving it to another file?
* The [**failed to parse notification payload**](https://github.com/siku2/script.service.sponsorblock/pull/45/files#diff-fb4f0e5d3711634b047f71c3a8b8dfedab5d8fc1fc766320858939e65964d98aR174) message will always go through when watching on Invidious. I'm not sure how to work with this since I don't have the YouTube app setup to review existing behavior or understand the purpose tbh.

### Related 

* Closes https://github.com/siku2/script.service.sponsorblock/issues/27
* Alternative for https://github.com/lekma/plugin.video.invidious/issues/71