### PR TITLE
feat: support get segments with hash

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -166,3 +166,11 @@ msgstr ""
 msgctxt "#32027"
 msgid "SponsorBlock Settings"
 msgstr ""
+
+msgctxt "#32042"
+msgid "Extra Privacy"
+msgstr ""
+
+msgctxt "#32043"
+msgid "Preserves privacy but uses more bandwidth. Instead of requesting segments for a single video, queries for a batch of videos to prevent the SponsorBlock server from tracking your watch history."
+msgstr ""

--- a/resources/lib/player_listener.py
+++ b/resources/lib/player_listener.py
@@ -15,6 +15,7 @@ from .utils.const import (
     CONF_SHOW_SKIPPED_DIALOG,
     CONF_SKIP_COUNT_TRACKING,
     CONF_VIDEO_END_TIME_MARGIN_MS,
+    CONF_EXTRA_PRIVACY,
 )
 
 logger = logging.getLogger(__name__)
@@ -40,7 +41,8 @@ def get_sponsor_segments(
     api, video_id
 ):  # type: (SponsorBlockAPI, str) -> Optional[list[SponsorSegment]]
     try:
-        segments = api.get_skip_segments(video_id)
+        extra_privacy = addon.get_config(CONF_EXTRA_PRIVACY, bool)
+        segments = api.get_skip_segments_hashed(video_id) if extra_privacy else api.get_skip_segments(video_id)
     except NotFound:
         logger.info("video %s has no sponsor segments", video_id)
         return None

--- a/resources/lib/sponsorblock/api.py
+++ b/resources/lib/sponsorblock/api.py
@@ -108,7 +108,6 @@ class SponsorBlockAPI:
         Returns:
             List of segments for the video, or an empty list if no segments were found.
         """
-        video_id = video_id[0]
         m = hashlib.sha256()
         m.update(video_id.encode())
         m.digest()

--- a/resources/lib/sponsorblock/api.py
+++ b/resources/lib/sponsorblock/api.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import logging
 
@@ -79,7 +80,7 @@ class SponsorBlockAPI:
 
     def get_skip_segments(
         self, video_id
-    ):  # type: (str, List[str]) -> List[SponsorSegment]
+    ):  # type: (str, bool) -> list[SponsorSegment]
         params = {
             "videoID": video_id,
             "categories": self._categories_param,
@@ -92,6 +93,42 @@ class SponsorBlockAPI:
             start, end = raw["segment"]
             seg = SponsorSegment(raw["UUID"], raw["category"], start, end)
             segments.append(seg)
+
+        segments.sort(key=lambda seg: seg.start)
+        return segments
+
+    def get_skip_segments_hashed(self, video_id):   # type: (str) -> list[SponsorSegment]
+        """
+        Privacy preserving varient of /api/skipSegments.
+        This uses more bandwidth, but doesn't indicate to the server which video
+        specifically the client was watching.
+
+        See also: https://wiki.sponsor.ajay.app/w/API_Docs#GET_/api/skipSegments/:sha256HashPrefix
+
+        Returns:
+            List of segments for the video, or an empty list if no segments were found.
+        """
+        video_id = video_id[0]
+        m = hashlib.sha256()
+        m.update(video_id.encode())
+        m.digest()
+        id_hash = m.hexdigest()[:4]
+
+        params = {
+            "categories": self._categories_param
+        }
+
+        data = self._request("GET", GET_SKIP_SEGMENTS + "/" + id_hash, params)
+        segments = []
+
+        for video in data:
+            if video_id == video["videoID"]:
+                for raw in video["segments"]:
+                    start, end = raw["segment"]
+                    seg = SponsorSegment(raw["UUID"], raw["category"], start, end)
+                    segments.append(seg)
+
+                break
 
         segments.sort(key=lambda seg: seg.start)
         return segments

--- a/resources/lib/utils/const.py
+++ b/resources/lib/utils/const.py
@@ -1,4 +1,5 @@
 CONF_API_SERVER = "api_server"
+CONF_EXTRA_PRIVACY = "extra_privacy"
 CONF_AUTO_UPVOTE = "auto_upvote"
 CONF_IGNORE_UNLISTED = "ignore_unlisted"
 CONF_SEGMENT_CHAIN_MARGIN_MS = "segment_chain_margin_ms"

--- a/resources/lib/youtube_api.py
+++ b/resources/lib/youtube_api.py
@@ -155,7 +155,9 @@ DOMAIN_GOOGLEVIDEO = "googlevideo.com"
 def get_video_id():  # type: () -> Option[str]
     """Get the video id for the playing item.
 
-    Example path: `plugin://plugin.video.youtube/play/?video_id=SQCfOjhguO0`
+    Example paths:
+    * `plugin://plugin.video.youtube/play/?video_id=SQCfOjhguO0`
+    * `plugin://plugin.video.invidious/?action=video&videoId=SQCfOjhguO0`
 
     Returns:
         Video ID that is being played. `None` if the current item isn't a YouTube video.
@@ -175,7 +177,7 @@ def get_video_id():  # type: () -> Option[str]
     )
     if valid_url:
         query = urlparse.parse_qs(path_url.query)
-        return query.get(uri_filter["query"])
+        return query.get(uri_filter["query"])[0]
 
     # has_context denotes whether the current video seems to be a youtube video
     # being played outside of the YouTube add-on.

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -126,6 +126,13 @@
                     </control>
                 </setting>
             </group>
+            <group id="3" label="">
+                <setting id="extra_privacy" type="boolean" label="32042" help="32043">
+                    <level>3</level>
+                    <default>false</default>
+                    <control type="toggle"/>
+                </setting>
+            </group>
         </category>
     </section>
 </settings>


### PR DESCRIPTION
Supports the endpoint to get video segments with the first 4 characters of a video SHA256 hash.

More info: https://wiki.sponsor.ajay.app/w/API_Docs#GET_/api/skipSegments/:sha256HashPrefix

### Notes

Weird thing to look out for, but over here:
https://github.com/SethFalco/script.service.sponsorblock/blob/279d9e8da5a8ba9be70e7b4bfd62bea532b12560/resources/lib/sponsorblock/api.py#L111

Despite the types suggesting it's a `str`, it's actually a `list[str]`. I was trying to figure out why, but it's actually a `list[str]` from all the way up from `PlayerListener#_prepare_segments`, so I thought I'd leave it for now.