### PR TITLE
fix: remove redundant check

### DIFF
--- a/resources/lib/player_listener.py
+++ b/resources/lib/player_listener.py
@@ -171,14 +171,9 @@ class PlayerListener(PlayerCheckpointListener):
             return False
 
         chained_end = self.__get_segment_end_handle_overlap(seg)
-        min_skip_position = current_time + reduce_skips_seconds
 
-        if chained_end < min_skip_position:
-            logger.debug("skipping segment %s because there is not enough margin for 'Reduce all skips by this much' setting (%g)", seg, reduce_skips_seconds)
-            return False
-
-        if chained_end - seg.start < reduce_skips_seconds:
-            logger.debug("skipping segment %s because it is shorter than 'Reduce all skips by this much' setting (%g)", seg, reduce_skips_seconds)
+        if chained_end - seg.start <= reduce_skips_seconds:
+            logger.debug("not applying segment %s because it is shorter than 'Reduce all skips by this much' setting (%g seconds)", seg, reduce_skips_seconds)
             return False
 
         return True


### PR DESCRIPTION
I could be wrong, so please do review and tell me what you think!
When I saw this, the first check looked redundant. :thinking: 

The first condition can never be true if the one below is false. So, we might as well only check the second condition.

Just to be certain, I ran some number through my head, which I couldn't come up with a scenario where the first condition would match where the second condition wouldn't.

To take it further, I also wrote a script to brute force this and see if the last condition ever occurs:

```sh
#!/bin/bash

for combo in {0..10}:{0..10}:{0..10}:{0..10}
do
  IFS=':' read A B C D <<< $combo
  
  chained_end=$A
  current_time=$B
  reduce_skips_seconds=$C
  seg_start=$D
  min_skip_position=$(( B + C ))
  
  if [[ $chained_end -lt $current_time ]]
  then
    continue
  fi

  if [[ $seg_start -lt $current_time ]]
  then
    continue
  fi

  if [[ $(( $chained_end - $seg_start )) -lt $reduce_skips_seconds ]]
  then
    continue
  fi

  if [[ $chained_end -lt $min_skip_position ]]
  then
    echo "This isn't possible, is it?"
    exit 0
  fi
done

echo "Nah, never happened."
```

This prints `Nah, never happened.`.

### Notes

* While I'm at it, I replace the `<` with `<=` because if they are equal, there's still no need to apply the segment. (In theory, it just wouldn't move the cursor at all.)
* In the debug log, adds `seconds` to the time parameter, so its users know the units were changed between the config and the log. Otherwise, it looks like it has the wrong value compared to the config.
* This also applies a very minor rewording since in a plugin like this, it's unclear if "skipping segment" means it's skipping the section of the video, or skipping skipping that section of the video. I think using the terms "applying" or "not applying" is less ambiguous. ^-^'

### Related

* Code introduced by https://github.com/siku2/script.service.sponsorblock/pull/31