### PR TITLE
chore: correct extra privacy message id

### DIFF
--- a/resources/language/resource.language.en_gb/strings.po
+++ b/resources/language/resource.language.en_gb/strings.po
@@ -174,10 +174,10 @@ msgctxt "#32027"
 msgid "SponsorBlock Settings"
 msgstr ""
 
-msgctxt "#32042"
+msgctxt "#32044"
 msgid "Extra Privacy"
 msgstr ""
 
-msgctxt "#32043"
+msgctxt "#32045"
 msgid "Preserves privacy but uses more bandwidth. Instead of requesting segments for a single video, queries for a batch of videos to prevent the SponsorBlock server from tracking your watch history."
 msgstr ""

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -132,7 +132,7 @@
                 </setting>
             </group>
             <group id="3" label="">
-                <setting id="extra_privacy" type="boolean" label="32042" help="32043">
+                <setting id="extra_privacy" type="boolean" label="32044" help="32045">
                     <level>3</level>
                     <default>false</default>
                     <control type="toggle"/>


### PR DESCRIPTION
During my previous PRs, I accidentally introduced multiple messages with the same ID, so some of the settings are showing the wrong string in the UI.

### Related

* https://github.com/siku2/script.service.sponsorblock/commit/2ecfcc85033c4f98faab3bd762be2e954b21aaa1#diff-a3f31c5653172d109f0194bd9beca357f050124d012c1202d20cabb7ecd36816R74
* https://github.com/siku2/script.service.sponsorblock/commit/921fdb0a6121594521335eb3f44850c501935ce7#diff-a3f31c5653172d109f0194bd9beca357f050124d012c1202d20cabb7ecd36816R170

This separated them, so that the "Extra Privacy" setting will show the correct label and help.