### PR TITLE
fix: return early if unsupported app

### DIFF
--- a/resources/lib/player_listener.py
+++ b/resources/lib/player_listener.py
@@ -128,7 +128,12 @@ class PlayerListener(PlayerCheckpointListener):
 
         with self._should_start_lock:
             addon_id = get_playing_addon()
-            video_id = get_api(addon_id).get_video_id()
+            api = get_api(addon_id)
+
+            if not api:
+                return
+
+            video_id = api.get_video_id()
 
             if not video_id:
                 return


### PR DESCRIPTION
Whenever I open a video on an app SponsorBlock doesn't support, it throws an exception.
This adds a check if `get_api` returns a non-None object, if so then do nothing and exit early.

Example exception:

```
2023-06-21 18:32:28.072 T:922      info <general>: VideoPlayer::OpenFile: plugin://plugin.video.imdb.trailers/?action=play&videoid=vi105104409
2023-06-21 18:32:28.232 T:18516    info <general>: Creating InputStream
2023-06-21 18:32:28.242 T:29736   error <general>: EXCEPTION Thrown (PythonToCppException) : -->Python callback/script returned the following error<--
                                                    - NOTE: IGNORING THIS CAN LEAD TO MEMORY LEAKS!
                                                   Error Type: <class 'AttributeError'>
                                                   Error Contents: 'NoneType' object has no attribute 'get_video_id'
                                                   Traceback (most recent call last):
                                                     File "/storage/.kodi/addons/script.service.sponsorblock/resources/lib/player_listener.py", line 131, in onPlayBackStarted
                                                       video_id = get_api(addon_id).get_video_id()
                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                                                   AttributeError: 'NoneType' object has no attribute 'get_video_id'
                                                   -->End of Python script error report<--
```

### Related

* Bug introduced by https://github.com/siku2/script.service.sponsorblock/pull/49/files#diff-cf9563a663e5becc98888c58d27605a216ee886cfca693cc3c88c83242327b65R130