### PR TITLE
Fix 'failed to parse notification payload'

### DIFF
--- a/resources/lib/apis/youtube_api.py
+++ b/resources/lib/apis/youtube_api.py
@@ -35,8 +35,7 @@ unique ids that require context
 class YouTubeApi(AbstractApi):
 
     def parse_notification_payload(self, data):  # type: (str) -> NotificationPayload | None
-        args = json.loads(data)
-        parsed = json.loads(urlparse.unquote(args[0]))
+        parsed = json.loads(data)
         return NotificationPayload(parsed.get("video_id", None), parsed.get("unlisted", None))
 
     def get_video_id(self):  # type: () -> str | None


### PR DESCRIPTION
This PR fixes https://github.com/siku2/script.service.sponsorblock/issues/67 using the method suggested by @ehoffman2.

It has been tested on my nixos-based kodi on videos that didn't work before the fix.