### PR TITLE
Fix Kodi addon checker workflow

### DIFF
--- a/.github/workflows/addon-check.yaml
+++ b/.github/workflows/addon-check.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v7
 
     - name: Clean workspace
       run: |
@@ -16,6 +16,6 @@ jobs:
 
     - name: Kodi addon checker validation
       id: kodi-addon-checker
-      uses: xbmc/action-kodi-addon-checker@v1.0
+      uses: xbmc/action-kodi-addon-checker@v1.3
       with:
         kodi-version: matrix


### PR DESCRIPTION
## Summary

- upgrade `xbmc/action-kodi-addon-checker` from v1.0 to v1.3
- upgrade `actions/checkout` from v2 to v7

## Root cause

The Kodi add-on check triggered after #72 merged failed before validating the add-on. The v1.0 checker action runs Python 3.7 but dynamically installs a current `kodi-addon-checker` release that uses Python 3.8+ assignment-expression syntax. Importing the checker therefore raises a `SyntaxError`.

The maintained v1.3 action uses Python 3.10 while preserving the existing `kodi-version: matrix` input. Updating checkout also removes the deprecated runtime warning emitted for v2.

Failed run: https://github.com/siku2/script.service.sponsorblock/actions/runs/31915580900/job/95086776214

## Validation

- workflow YAML parsed successfully
- `git diff --check`
- `python3 -m unittest discover -v` — 7 tests passed
